### PR TITLE
实现了云盘的备份功能

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/GeertJohan/go.incremental v1.0.0
 	github.com/json-iterator/go v1.1.10
 	github.com/kardianos/osext v0.0.0-20170510131534-ae77be60afb1
+	github.com/mattn/go-sqlite3 v1.14.4
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/oleiade/lane v0.0.0-20160817071224-3053869314bb
 	github.com/olekukonko/tablewriter v0.0.2-0.20190618033246-cc27d85e17ce
@@ -13,7 +14,7 @@ require (
 	github.com/tickstep/cloudpan189-api v0.0.3
 	github.com/tickstep/library-go v0.0.2
 	github.com/urfave/cli v1.21.1-0.20190817182405-23c83030263f
-	golang.org/x/sys v0.0.0-20191025090151-53bf42e6b339 // indirect
+	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 // indirect
 )
 
 //replace github.com/tickstep/library-go => /Users/tickstep/Documents/Workspace/go/projects/library-go

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/tickstep/cloudpan189-api v0.0.3
 	github.com/tickstep/library-go v0.0.2
 	github.com/urfave/cli v1.21.1-0.20190817182405-23c83030263f
+	github.com/xujiajun/nutsdb v0.5.0
 	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/GeertJohan/go.incremental v1.0.0 h1:7AH+pY1XUgQE4Y1HcXYaMqAI0m9yrFqo/jt0CW30vsg=
 github.com/GeertJohan/go.incremental v1.0.0/go.mod h1:6fAjUhbVuX1KcMD3c8TEgVUqmo4seqhv0i0kdATSkM0=
+github.com/bwmarrin/snowflake v0.3.0 h1:xm67bEhkKh6ij1790JB83OujPR5CzNe8QuQqAgISZN0=
+github.com/bwmarrin/snowflake v0.3.0/go.mod h1:NdZxfVWX+oR6y2K0o6qAYv6gIOP9rjG0/E9WsDpxqwE=
 github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -54,9 +56,17 @@ github.com/tickstep/library-go v0.0.2 h1:0JCxT2ZzRMrydUyqou3d9FI44ULrlxnkFcyioaG
 github.com/tickstep/library-go v0.0.2/go.mod h1:egoK/RvOJ3Qs2tHpkq374CWjhNjI91JSCCG1GrhDYSw=
 github.com/urfave/cli v1.21.1-0.20190817182405-23c83030263f h1:xKDKjIsL76VUyHcA0G4Qe1cIAUB/nrq6Pt8D411bd1g=
 github.com/urfave/cli v1.21.1-0.20190817182405-23c83030263f/go.mod h1:qXyCeJubPqsgeiLd3kvHOGHHSrQcNdjZ2ScXIcVZK/I=
+github.com/xujiajun/gorouter v1.2.0/go.mod h1:yJrIta+bTNpBM/2UT8hLOaEAFckO+m/qmR3luMIQygM=
+github.com/xujiajun/mmap-go v1.0.1 h1:7Se7ss1fLPPRW+ePgqGpCkfGIZzJV6JPq9Wq9iv/WHc=
+github.com/xujiajun/mmap-go v1.0.1/go.mod h1:CNN6Sw4SL69Sui00p0zEzcZKbt+5HtEnYUsc6BKKRMg=
+github.com/xujiajun/nutsdb v0.5.0 h1:j/jM3Zw7Chg8WK7bAcKR0Xr7Mal47U1oJAMgySfDn9E=
+github.com/xujiajun/nutsdb v0.5.0/go.mod h1:owdwN0tW084RxEodABLbO7h4Z2s9WiAjZGZFhRh0/1Q=
+github.com/xujiajun/utils v0.0.0-20190123093513-8bf096c4f53b h1:jKG9OiL4T4xQN3IUrhUpc1tG+HfDXppkgVcrAiiaI/0=
+github.com/xujiajun/utils v0.0.0-20190123093513-8bf096c4f53b/go.mod h1:AZd87GYJlUzl82Yab2kTjx1EyXSQCAfZDhpTo1SQC4k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20181221143128-b4a75ba826a6/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/mattn/go-runewidth v0.0.3/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-sqlite3 v1.14.4 h1:4rQjbDxdu9fSgI/r3KN72G3c2goxknAqHHgPWWs8UlI=
+github.com/mattn/go-sqlite3 v1.14.4/go.mod h1:WVKg1VTActs4Qso6iwGbiFih2UIHo0ENGwNd0Lj+XmI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -58,8 +60,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191025090151-53bf42e6b339 h1:zSqWKgm/o7HAnlAzBQ+aetp9fpuyytsXnKA8eiLHYQM=
-golang.org/x/sys v0.0.0-20191025090151-53bf42e6b339/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 h1:LfCXLvNmTYH9kEmVgqbnsWfruoXZIrh4YBgqVHtDvw0=
+golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -14,9 +14,17 @@
 package command
 
 import (
+	"errors"
+	"strconv"
+
+	"github.com/urfave/cli"
+
 	"github.com/tickstep/cloudpan189-api/cloudpan"
 	"github.com/tickstep/cloudpan189-go/internal/config"
 )
+
+var ErrBadArgs = errors.New("参数错误")
+var ErrNotLogined = errors.New("未登录账号")
 
 func GetActivePanClient() *cloudpan.PanClient {
 	return config.Config.ActiveUser().PanClient()
@@ -24,4 +32,17 @@ func GetActivePanClient() *cloudpan.PanClient {
 
 func GetActiveUser() *config.PanUser {
 	return config.Config.ActiveUser()
+}
+
+func parseFamilyId(c *cli.Context) int64 {
+	familyId := config.Config.ActiveUser().ActiveFamilyId
+	if c.IsSet("familyId") {
+		fid, errfi := strconv.ParseInt(c.String("familyId"), 10, 64)
+		if errfi != nil {
+			familyId = 0
+		} else {
+			familyId = fid
+		}
+	}
+	return familyId
 }

--- a/internal/command/upload.go
+++ b/internal/command/upload.go
@@ -159,11 +159,13 @@ func RunUpload(localPaths []string, savePath string, opt *UploadOptions) {
 		}
 
 		if fi, err := os.Stat(curPath); err == nil && fi.IsDir() {
-			db, _ = panupload.OpenSyncDb(localPathDir+string(os.PathSeparator)+fi.Name()+string(os.PathSeparator)+".ecloud"+string(os.PathSeparator)+"db", "ecloud")
+			db, err = panupload.OpenSyncDb(localPathDir+string(os.PathSeparator)+fi.Name()+string(os.PathSeparator)+".ecloud"+string(os.PathSeparator)+"db", "ecloud")
 			if db != nil {
 				defer func(syncDb *panupload.FolderSyncDb) {
 					db.Close()
 				}(db)
+			} else {
+				fmt.Println(err)
 			}
 		}
 

--- a/internal/command/upload.go
+++ b/internal/command/upload.go
@@ -159,13 +159,21 @@ func RunUpload(localPaths []string, savePath string, opt *UploadOptions) {
 		}
 
 		if fi, err := os.Stat(curPath); err == nil && fi.IsDir() {
-			db, err = panupload.OpenSyncDb(localPathDir+string(os.PathSeparator)+fi.Name()+string(os.PathSeparator)+".ecloud"+string(os.PathSeparator)+"db", "ecloud")
-			if db != nil {
-				defer func(syncDb *panupload.FolderSyncDb) {
-					db.Close()
-				}(db)
-			} else {
-				fmt.Println(err)
+			//使用绝对路径避免异常
+			dbpath, err := filepath.Abs(curPath)
+			if err != nil {
+				dbpath = curPath
+			}
+			dbpath += string(os.PathSeparator) + ".ecloud"
+			if di, err := os.Stat(dbpath); err == nil && di.IsDir() {
+				db, err = panupload.OpenSyncDb(dbpath+string(os.PathSeparator)+"db", "ecloud")
+				if db != nil {
+					defer func(syncDb *panupload.FolderSyncDb) {
+						db.Close()
+					}(db)
+				} else {
+					fmt.Println(err)
+				}
 			}
 		}
 

--- a/internal/functions/panupload/sync_database_nustdb.go
+++ b/internal/functions/panupload/sync_database_nustdb.go
@@ -1,0 +1,46 @@
+//+build !sqlite
+
+package panupload
+
+import (
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/xujiajun/nutsdb"
+)
+
+type FolderSyncDb struct {
+	db     *nutsdb.DB
+	bucket string
+}
+
+func OpenSyncDb(file string, bucket string) (*FolderSyncDb, error) {
+	opt := nutsdb.DefaultOptions
+	opt.Dir = file
+	opt.EntryIdxMode = nutsdb.HintBPTSparseIdxMode
+	db, err := nutsdb.Open(opt)
+	if err != nil {
+		return nil, err
+	}
+	return &FolderSyncDb{db: db, bucket: bucket}, nil
+}
+func (db *FolderSyncDb) Get(key string) []byte {
+	var data []byte
+	db.db.View(func(tx *nutsdb.Tx) error {
+		ent, err := tx.Get(db.bucket, []byte(key))
+		if err != nil {
+			return err
+		}
+		data = ent.Value
+		return nil
+	})
+	return data
+}
+
+func (db *FolderSyncDb) Put(key string, value []byte) error {
+	return db.db.Update(func(tx *nutsdb.Tx) error {
+		return tx.Put(db.bucket, []byte(key), value, 0)
+	})
+}
+
+func (db *FolderSyncDb) Close() error {
+	return db.db.Close()
+}

--- a/internal/functions/panupload/sync_database_sqlite.go
+++ b/internal/functions/panupload/sync_database_sqlite.go
@@ -1,0 +1,48 @@
+package panupload
+
+import (
+	"database/sql"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+type FolderSyncDb struct {
+	db     *sql.DB
+	bucket []byte
+}
+
+func OpenSyncDb(file string, bucket string) (*FolderSyncDb, error) {
+	db, err := sql.Open("sqlite3", file+"_sqlite.db")
+	if err != nil {
+		return nil, err
+	}
+	_, err = db.Exec("CREATE TABLE IF NOT EXISTS ecloud (path varchar PRIMARY KEY,data JSON)")
+	if err != nil {
+		return nil, err
+	}
+
+	return &FolderSyncDb{db: db, bucket: []byte(bucket)}, nil
+}
+func (db *FolderSyncDb) Get(key string) []byte {
+	var data []byte
+	row := db.db.QueryRow("select data from ecloud where path=?", key)
+	row.Scan(&data)
+	return data
+}
+
+func (db *FolderSyncDb) Put(key string, value []byte) error {
+	var t int
+	var err error
+	row := db.db.QueryRow("select 1 from ecloud where path=?", key)
+	row.Scan(&t)
+	if t > 0 {
+		_, err = db.db.Exec("update ecloud set data=? where path=?", value, key)
+	} else {
+		_, err = db.db.Exec("insert into ecloud values(?,?)", key, value)
+	}
+	return err
+}
+
+func (db *FolderSyncDb) Close() error {
+	return db.db.Close()
+}

--- a/internal/functions/panupload/upload.go
+++ b/internal/functions/panupload/upload.go
@@ -15,20 +15,21 @@ package panupload
 
 import (
 	"context"
+	"io"
+	"net/http"
+
 	"github.com/tickstep/cloudpan189-api/cloudpan"
 	"github.com/tickstep/cloudpan189-api/cloudpan/apierror"
 	"github.com/tickstep/cloudpan189-go/internal/file/uploader"
 	"github.com/tickstep/library-go/requester"
 	"github.com/tickstep/library-go/requester/rio"
-	"io"
-	"net/http"
 )
 
 type (
 	PanUpload struct {
-		panClient        *cloudpan.PanClient
+		panClient  *cloudpan.PanClient
 		targetPath string
-		familyId int64
+		familyId   int64
 
 		// UploadFileId 上传文件请求ID
 		uploadFileId string
@@ -38,6 +39,15 @@ type (
 		fileCommitUrl string
 		// 请求的X-Request-ID
 		xRequestId string
+	}
+
+	UploadedFileMeta struct {
+		Path    string `json:"path,omitempty"`    // 本地路径
+		Size    int64  `json:"length,omitempty"`  // 文件大小
+		MD5     string `json:"md5,omitempty"`     // 文件的 md5
+		ModTime int64  `json:"modtime,omitempty"` // 修改日期
+		FileID  int64  `json:"id,omitempty"`      //文件、目录ID
+		Rev     int64  `json:"rev,omitempty"`     //文件版本
 	}
 
 	EmptyReaderLen64 struct {
@@ -56,7 +66,7 @@ func NewPanUpload(panClient *cloudpan.PanClient, targetPath, uploadUrl, commitUr
 	return &PanUpload{
 		panClient:     panClient,
 		targetPath:    targetPath,
-		familyId: familyId,
+		familyId:      familyId,
 		uploadFileId:  uploadFileId,
 		fileUploadUrl: uploadUrl,
 		fileCommitUrl: commitUrl,
@@ -80,7 +90,7 @@ func (pu *PanUpload) UploadFile(ctx context.Context, partseq int, partOffset int
 	var respErr *uploader.MultiError
 	fileRange := &cloudpan.AppFileUploadRange{
 		Offset: partOffset,
-		Len: partEnd - partOffset,
+		Len:    partEnd - partOffset,
 	}
 	var apiError *apierror.ApiError
 	uploadFunc := func(httpMethod, fullUrl string, headers map[string]string) (resp *http.Response, err error) {

--- a/internal/localfile/localfile.go
+++ b/internal/localfile/localfile.go
@@ -16,11 +16,12 @@ package localfile
 import (
 	"crypto/md5"
 	"encoding/hex"
-	"github.com/tickstep/library-go/cachepool"
-	"github.com/tickstep/library-go/converter"
 	"hash/crc32"
 	"io"
 	"os"
+
+	"github.com/tickstep/library-go/cachepool"
+	"github.com/tickstep/library-go/converter"
 )
 
 const (
@@ -39,32 +40,32 @@ const (
 type (
 	// LocalFileMeta 本地文件元信息
 	LocalFileMeta struct {
-		Path     string `json:"path"`     // 本地路径
-		Length   int64  `json:"length"`   // 文件大小
-		MD5      string `json:"md5"`      // 文件的 md5
-		CRC32    uint32 `json:"crc32"`    // 文件的 crc32
-		ModTime  int64  `json:"modtime"`  // 修改日期
+		Path    string `json:"path,omitempty"`   // 本地路径
+		Length  int64  `json:"length,omitempty"` // 文件大小
+		MD5     string `json:"md5,omitempty"`    // 文件的 md5
+		CRC32   uint32 `json:"crc32,omitempty"`  // 文件的 crc32
+		ModTime int64  `json:"modtime"`          // 修改日期
 
 		// ParentFolderId 存储云盘的目录ID
-		ParentFolderId string `json:"parent_folder_id"`
+		ParentFolderId string `json:"parent_folder_id,omitempty"`
 		// UploadFileId 上传文件请求ID
-		UploadFileId string `json:"upload_file_id"`
+		UploadFileId string `json:"upload_file_id,omitempty"`
 		// FileUploadUrl 上传文件数据的URL路径
-		FileUploadUrl string `json:"file_upload_url"`
+		FileUploadUrl string `json:"file_upload_url,omitempty"`
 		// FileCommitUrl 上传文件完成后确认路径
-		FileCommitUrl string `json:"file_commit_url"`
+		FileCommitUrl string `json:"file_commit_url,omitempty"`
 		// FileDataExists 文件是否已存在云盘中，0-未存在，1-已存在
-		FileDataExists int `json:"file_data_exists"`
+		FileDataExists int `json:"file_data_exists,omitempty"`
 		// 请求的X-Request-ID
-		XRequestId string `json:"x_request_id"`
+		XRequestId string `json:"x_request_id,omitempty"`
 	}
 
 	// LocalFileEntity 校验本地文件
 	LocalFileEntity struct {
 		LocalFileMeta
-		bufSize   int
-		buf       []byte
-		file      *os.File // 文件
+		bufSize int
+		buf     []byte
+		file    *os.File // 文件
 	}
 )
 
@@ -77,7 +78,7 @@ func NewLocalFileEntityWithBufSize(localPath string, bufSize int) *LocalFileEnti
 		LocalFileMeta: LocalFileMeta{
 			Path: localPath,
 		},
-		bufSize:   bufSize,
+		bufSize: bufSize,
 	}
 }
 


### PR DESCRIPTION
1. 数据库记录已备份完成的文件。
2. 下次再备份时直接通过文件大小和修改日期判断是否有修改。
3. 如果第二步判断失败再判断MD5是否一致。
4. 通过以上步骤实现快速过滤需上传的文件，节省网络和资源占用。

注： 在需备份的目录下创建`.ecloud`目录才可以启用该功能，并且会默认使用`-ow`参数。

关联 issue #7  #16 